### PR TITLE
Disabled merchant items dm

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -16,8 +16,8 @@ class Admin::MerchantsController < Admin::BaseController
       flash[:success] = "#{merchant.name} has been disabled"
     else
       merchant.update(status: 0)
-      merchant.deactivate_items
-      flash[:success] = "#{merchantname} has been enabled"
+      merchant.activate_items
+      flash[:success] = "#{merchant.name} has been enabled"
     end
     redirect_to '/admin/merchants'
   end

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -11,10 +11,12 @@ class Admin::MerchantsController < Admin::BaseController
   def update
     merchant = Merchant.find(params[:id])
     if merchant.enabled?
-      merchant.update(status: "disabled")
+      merchant.update(status: 1)
+      merchant.deactivate_items
       flash[:success] = "#{merchant.name} has been disabled"
     else
-      merchant.update(status: "enabled")
+      merchant.update(status: 0)
+      merchant.deactivate_items
       flash[:success] = "#{merchantname} has been enabled"
     end
     redirect_to '/admin/merchants'

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -28,4 +28,17 @@ class Merchant <ApplicationRecord
   def distinct_cities
     item_orders.distinct.joins(:order).pluck(:city)
   end
+
+  def deactivate_items
+    items.each do |item|
+      item.update(active?: false)
+    end
+  end
+
+  def activate_items
+    items.each do |item|
+      item.update(active?: true)
+    end
+  end
+  
 end

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -5,9 +5,9 @@
     <section id="merchant-<%= merchant.id %>">
       <h2><%=link_to merchant.name, "/merchants/#{merchant.id}"%></h2>
       <% if merchant.enabled? %>
-        <h2><%= button_to 'Disable Merchant', "/admin/merchants/#{merchant.id}", method: :patch %></h2>
+        <h2><%= button_to 'Disable', "/admin/merchants/#{merchant.id}", method: :patch %></h2>
       <% else %>
-        <h2><%=button_to "Enable", admin_merchants_path%></h2>
+        <h2><%= button_to 'Enable', "/admin/merchants/#{merchant.id}", method: :patch %></h2>
       <% end %>
     </section>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,8 +61,6 @@ Rails.application.routes.draw do
   namespace :admin do
     get '/', to: 'dashboard#index'
     resources :merchants, only: [:index, :update, :show]
-    # get 'merchants', to: 'merchants#index'
-    # patch '/merchants/:id', to: 'merchants#update'
     get '/users/:user_id', to: 'user#show'
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200225011155) do
+ActiveRecord::Schema.define(version: 20200225014325) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/features/admin/merchant/index_spec.rb
+++ b/spec/features/admin/merchant/index_spec.rb
@@ -129,11 +129,3 @@ describe "As an admin" do
     end 
   end
 end
-
-
-# As an admin
-# When I visit the merchant index page
-# I see an "enable" button next to any merchants whose accounts are disabled
-# When I click on the "enable" button
-# I am returned to the admin's merchant index page where I see that the merchant's account is now enabled
-# And I see a flash message that the merchant's account is now enabled

--- a/spec/features/admin/merchant/index_spec.rb
+++ b/spec/features/admin/merchant/index_spec.rb
@@ -9,6 +9,8 @@ describe "As an admin" do
     @merchant_2 = create(:random_merchant)
     @item_1 = create(:random_item, merchant_id: @merchant_1.id)
     @item_2 = create(:random_item, merchant_id: @merchant_1.id)
+    @item_3 = create(:random_item, merchant_id: @merchant_2.id)
+    @item_4 = create(:random_item, merchant_id: @merchant_2.id)
     end 
 
     it "I am able to disable a merchant" do
@@ -25,9 +27,11 @@ describe "As an admin" do
         click_button "Disable"
       end 
 
-
+      @merchant_1.reload
+      
       expect(current_path).to eq('/admin/merchants')
       expect(page).to have_content("#{@merchant_1.name} has been disabled")
+      expect(@merchant_1.status).to eq('disabled') 
      
       within "#merchant-#{@merchant_1.id}" do
         expect(page).to_not have_button('Disable')
@@ -38,5 +42,39 @@ describe "As an admin" do
         expect(page).to have_button('Disable')
       end       
     end
+
+    it "clicking on 'disable' button decactivates that merchant's items" do 
+      visit '/admin/merchants'
+
+      within "#merchant-#{@merchant_1.id}" do
+        click_button "Disable"
+      end 
+      
+      @merchant_1.reload
+      @item_1.reload
+      @item_2.reload
+      @item_3.reload
+
+      visit '/admin/merchants'
+    
+      expect(@item_1.active?).to eq(false)
+      expect(@item_2.active?).to eq(false)
+      
+      regular = create(:regular_user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(regular)
+
+      visit '/items'
+
+      expect(page).not_to have_content(@item_1.name)
+      expect(page).not_to have_css("img[src*='#{@item_1.image}']")
+      expect(page).not_to have_content(@item_2.name)
+      expect(page).not_to have_css("img[src*='#{@item_2.image}']")
+      expect(page).to have_content(@item_3.name)
+      expect(page).to have_css("img[src*='#{@item_3.image}']")
+      expect(page).to have_content(@item_4.name)
+      expect(page).to have_css("img[src*='#{@item_4.image}']")
+    end 
   end
 end
+
+

--- a/spec/features/admin/merchant/index_spec.rb
+++ b/spec/features/admin/merchant/index_spec.rb
@@ -32,20 +32,20 @@ describe "As an admin" do
       expect(current_path).to eq('/admin/merchants')
       expect(page).to have_content("#{@merchant_1.name} has been disabled")
       expect(@merchant_1.status).to eq('disabled') 
-     
+      
       within "#merchant-#{@merchant_1.id}" do
         expect(page).to_not have_button('Disable')
         expect(page).to have_button('Enable')
       end 
-
+      
       within "#merchant-#{@merchant_2.id}" do
         expect(page).to have_button('Disable')
       end       
     end
-
+    
     it "clicking on 'disable' button decactivates that merchant's items" do 
       visit '/admin/merchants'
-
+      
       within "#merchant-#{@merchant_1.id}" do
         click_button "Disable"
       end 
@@ -54,17 +54,17 @@ describe "As an admin" do
       @item_1.reload
       @item_2.reload
       @item_3.reload
-
+      
       visit '/admin/merchants'
-    
+      
       expect(@item_1.active?).to eq(false)
       expect(@item_2.active?).to eq(false)
       
       regular = create(:regular_user)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(regular)
-
+      
       visit '/items'
-
+      
       expect(page).not_to have_content(@item_1.name)
       expect(page).not_to have_css("img[src*='#{@item_1.image}']")
       expect(page).not_to have_content(@item_2.name)
@@ -74,7 +74,66 @@ describe "As an admin" do
       expect(page).to have_content(@item_4.name)
       expect(page).to have_css("img[src*='#{@item_4.image}']")
     end 
+    it "Admin can enable an merchant and it's items" do 
+      merchant_3 = create(:random_merchant, status: 1)
+      item_5 = create(:random_item, active?: false, merchant_id: merchant_3.id)
+      item_6 = create(:random_item, active?: false, merchant_id: merchant_3.id)
+      
+      expect(merchant_3.status).to eq('disabled')  
+      expect(item_5.active?).to eq(false)
+      expect(item_6.active?).to eq(false)
+      
+      visit '/admin/merchants'
+      
+      within "#merchant-#{merchant_3.id}" do
+        click_button 'Enable'
+      end 
+      
+      merchant_3.reload
+      item_5.reload
+      item_6.reload
+      
+      expect(merchant_3.status).to eq('enabled')  
+      expect(item_5.active?).to eq(true)
+      expect(item_6.active?).to eq(true)
+      expect(page).to have_content("#{merchant_3.name} has been enabled")
+    end 
+    it "clicking on 'enabled' button activates that merchant's items" do 
+      merchant_3 = create(:random_merchant, status: 1)
+      item_5 = create(:random_item, active?: false, merchant_id: merchant_3.id)
+      item_6 = create(:random_item, active?: false, merchant_id: merchant_3.id)
+      
+      expect(merchant_3.status).to eq('disabled')  
+      expect(item_5.active?).to eq(false)
+      expect(item_6.active?).to eq(false)
+      
+      visit '/admin/merchants'
+      
+      within "#merchant-#{merchant_3.id}" do
+        click_button 'Enable'
+      end 
+      
+      merchant_3.reload
+      item_5.reload
+      item_6.reload
+      
+      regular = create(:regular_user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(regular)
+      
+      visit '/items'
+      
+      expect(page).to have_content(item_5.name)
+      expect(page).to have_css("img[src*='#{item_5.image}']")
+      expect(page).to have_content(item_6.name)
+      expect(page).to have_css("img[src*='#{item_6.image}']")
+    end 
   end
 end
 
 
+# As an admin
+# When I visit the merchant index page
+# I see an "enable" button next to any merchants whose accounts are disabled
+# When I click on the "enable" button
+# I am returned to the admin's merchant index page where I see that the merchant's account is now enabled
+# And I see a flash message that the merchant's account is now enabled

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -44,7 +44,7 @@ describe Merchant, type: :model do
       expect(@meg.average_item_price).to eq(70)
     end
 
-    xit 'distinct_cities' do
+   it 'distinct_cities' do
       chain = @meg.items.create(name: "Chain", description: "It'll never break!", price: 40, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 22)
       order_1 = @user.orders.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033)
       order_2 = @user.orders.create!(name: 'Brian', address: '123 Brian Ave', city: 'Denver', state: 'CO', zip: 17033)
@@ -56,5 +56,30 @@ describe Merchant, type: :model do
       expect(@meg.distinct_cities).to eq(["Denver","Hershey"])
     end
 
+    it ".deactivate_items" do
+      merchant_3 = create(:random_merchant, status: 0)
+      item_5 = create(:random_item, active?: false, merchant_id: merchant_3.id)
+      
+      expect(item_5.active?).to eq(false)
+
+      merchant_3.activate_items
+
+      item_5.reload
+
+      expect(item_5.active?).to eq(true)
+    end
+
+    it ".activate_items" do
+      merchant_3 = create(:random_merchant, status: 1)
+      item_5 = create(:random_item, merchant_id: merchant_3.id)
+      
+      expect(item_5.active?).to eq(true)
+
+      merchant_3.deactivate_items
+
+      item_5.reload
+
+      expect(item_5.active?).to eq(false)
+    end
   end
 end


### PR DESCRIPTION
**Functionality:**
Admin can disable/enable merchants and it's items

**Testing** (RSpec tests and development environment)
All RSPEC tests passing 

**Test %: 99.42%

**Related Issues:**


Notes:
Closes #40 
Closes #41 
Closes #42 